### PR TITLE
Fixed bug when scenario Order confirmed despite payment decline

### DIFF
--- a/Controller/Payment/Callback/Dmn.php
+++ b/Controller/Payment/Callback/Dmn.php
@@ -1060,7 +1060,7 @@ class Dmn extends Action implements CsrfAwareActionInterface
 //                $this->request->getPostValue()
 //            );
             
-            $orderId = $this->cartManagement->placeOrder($params);
+            $orderId = $this->cartManagement->placeOrder($params['quote']);
 
             $result
                 ->setData('success', true)


### PR DESCRIPTION
Steps to reproduce:

Webhook about a completed order is sent from Nuvei to Magento The order hasn't been created in Magento yet.
Expected result:

Order gets created in Magento automatically

Actual result:

Order is not created and is still missed in Magento while it is confirmed on the Nuvei side

Reason:

When trying to create an order in Nuvei\Checkout\Controller\Payment\Callback\Dmn::placeOrder() on line 1063, you're setting the $params variable which is an array of all the parameters sent in the webhook. But the requested method accepts only $quoteId as the first parameter.

Propose solution

Instead of:

$orderId = $this->cartManagement->placeOrder($params);

we should use:

$orderId = $this->cartManagement->placeOrder($params['quote']);